### PR TITLE
Removing WaitGroup

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"sort"
-	"sync"
 	"time"
 )
 
@@ -97,18 +96,13 @@ func main() {
 }
 
 func start() {
-	var wg sync.WaitGroup
 	for worker := 0; worker < concurrency; worker++ {
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
-
 			for m := range inputs {
 				m.HTTP()
 			}
 		}()
 	}
-	wg.Wait()
 }
 
 func report() {


### PR DESCRIPTION
The WaitGroup does not seem to be really useful in this context as `Start` is triggered in another goroutine. There's no real reason to wait for its completion.