### PR TITLE
Using time.Since

### DIFF
--- a/inputoutput.go
+++ b/inputoutput.go
@@ -46,7 +46,7 @@ func (i *input) benchmark(fn func() error) {
 
 	start := time.Now()
 	err := fn()
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 
 	o := output{
 		region:   i.region,


### PR DESCRIPTION
Using `time.Since(start)` instead of `time.Now().Sub(start)`