### PR TITLE
WaitGroup usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/GoogleCloudPlatform/gcping.svg?branch=master)](https://travis-ci.com/GoogleCloudPlatform/gcping)
 
 gcping is a command line tools that reports latency to
-Google Cloud regions. It is inspired by [gcping.com](https://gcping.com).
+Google Cloud regions. It is inspired by [gcping.com](http://gcping.com).
 
 ```
 gcping [options...]

--- a/pingserver/main.go
+++ b/pingserver/main.go
@@ -25,7 +25,7 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "hello")
 	})
-	port := os.Getenv("PORT")
+	port := os.Getenv("PORT") // makes it portable to Cloud Run
 	if port == "" {
 		port = "80"
 	}


### PR DESCRIPTION
Moving the WaitGroup.Wait to the parent goroutine. Otherwise, the channel could have been closed before to let the workers consuming all the input requests. 