### PR TITLE
Report median latency, not average

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/GoogleCloudPlatform/gcping.svg?branch=master)](https://travis-ci.com/GoogleCloudPlatform/gcping)
 
-gcping is a command line tools that reports latency to
+gcping is a command line tools that reports median latency to
 Google Cloud regions. It is inspired by [gcping.com](http://gcping.com).
 
 ```

--- a/inputoutput.go
+++ b/inputoutput.go
@@ -71,12 +71,18 @@ type output struct {
 	region    string
 	durations []time.Duration
 	errors    int
+
+	med time.Duration // median of durations; calculated on first call to median()
 }
 
-func (o output) median() time.Duration {
-	// Sort durations and pick the middle one.
-	sort.Slice(o.durations, func(i, j int) bool {
-		return o.durations[i] < o.durations[j]
-	})
-	return o.durations[len(o.durations)/2]
+func (o *output) median() time.Duration {
+	if o.med == 0 {
+		// Sort durations and pick the middle one.
+		sort.Slice(o.durations, func(i, j int) bool {
+			return o.durations[i] < o.durations[j]
+		})
+		o.med = o.durations[len(o.durations)/2]
+	}
+	return o.med
+
 }

--- a/inputoutput.go
+++ b/inputoutput.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 )
 
@@ -49,8 +50,8 @@ func (i *input) benchmark(fn func() error) {
 	duration := time.Since(start)
 
 	o := output{
-		region:   i.region,
-		duration: duration,
+		region:    i.region,
+		durations: []time.Duration{duration},
 	}
 	if err != nil {
 		o.errors++
@@ -67,26 +68,15 @@ func (i *input) benchmark(fn func() error) {
 }
 
 type output struct {
-	region   string
-	duration time.Duration
-	errors   int
+	region    string
+	durations []time.Duration
+	errors    int
 }
 
-type outputSorter struct {
-	averages []output
-}
-
-// Len is part of sort.Interface.
-func (s *outputSorter) Len() int {
-	return len(s.averages)
-}
-
-// Swap is part of sort.Interface.
-func (s *outputSorter) Swap(i, j int) {
-	s.averages[i], s.averages[j] = s.averages[j], s.averages[i]
-}
-
-// Less is part of sort.Interface.
-func (s *outputSorter) Less(i, j int) bool {
-	return s.averages[i].duration < s.averages[j].duration
+func (o output) median() time.Duration {
+	// Sort durations and pick the middle one.
+	sort.Slice(o.durations, func(i, j int) bool {
+		return o.durations[i] < o.durations[j]
+	})
+	return o.durations[len(o.durations)/2]
 }

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func report() {
 	})
 
 	tr := tabwriter.NewWriter(os.Stdout, 3, 2, 2, ' ', 0)
-	for i, a := range averages {
+	for i, a := range all {
 		fmt.Fprintf(tr, "%2d.\t[%v]\t%v", i+1, a.region, a.median())
 		if a.errors > 0 {
 			fmt.Fprintf(tr, "\t(%d errors)", a.errors)

--- a/main.go
+++ b/main.go
@@ -114,23 +114,24 @@ func report() {
 		a := m[o.region]
 
 		a.region = o.region
-		a.duration += o.duration
+		a.durations = append(a.durations, o.durations[0])
 		a.errors += o.errors
 
 		m[o.region] = a
 	}
-	averages := make([]output, 0, len(m))
+	all := make([]output, 0, len(m))
 	for _, t := range m {
-		t.duration = t.duration / time.Duration(number)
-		averages = append(averages, t)
+		all = append(all, t)
 	}
 
-	sorter := &outputSorter{averages: averages}
-	sort.Sort(sorter)
+	// sort all by median duration.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].median() < all[j].median()
+	})
 
 	tr := tabwriter.NewWriter(os.Stdout, 3, 2, 2, ' ', 0)
 	for i, a := range averages {
-		fmt.Fprintf(tr, "%2d.\t[%v]\t%v", i+1, a.region, a.duration)
+		fmt.Fprintf(tr, "%2d.\t[%v]\t%v", i+1, a.region, a.median())
 		if a.errors > 0 {
 			fmt.Fprintf(tr, "\t(%d errors)", a.errors)
 		}


### PR DESCRIPTION
Median latency is less susceptible to extreme outliers, and it's what gcping.com reports.

This PR also sorts using `sort.Slice` which is technically slower than satisfying `sort.Interface` but for the small number of values probably only imperceptibly so. Even so, median is only calculated once per region, to avoid unnecessary duplicate work. Regions are then `sort.Slice`d by median before display.

There's a bit of a silly hack whereby each `output` from each individual ping is initially stored with a single `time.Duration` value in the `[]durations` slice -- alternatives include adding a new single-value `duration` field (back), or just using a different struct for "one result" and "aggregation of results".