### PR TITLE
Add -top flag to print closest non-global region

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Options:
      By default 10; can't be negative or zero.
 -t   Timeout. By default, no timeout.
      Examples: "500ms", "1s", "1s500ms".
+-top If true, only the top (non-global) region is printed.
 
 -csv CSV output; disables verbose output.
 -v   Verbose output.

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ var endpoints = map[string]string{
 }
 
 var (
+	top         bool
 	number      int // number of requests for each region
 	concurrency int
 	timeout     time.Duration
@@ -64,6 +65,7 @@ var (
 )
 
 func main() {
+	flag.BoolVar(&top, "top", false, "")
 	flag.IntVar(&number, "n", 10, "")
 	flag.IntVar(&concurrency, "c", 10, "")
 	flag.DurationVar(&timeout, "t", time.Duration(0), "")
@@ -128,6 +130,15 @@ func report() {
 	sorter := &outputSorter{averages: averages}
 	sort.Sort(sorter)
 
+	if top {
+		t := averages[0].region
+		if t == "global" {
+			t = averages[1].region
+		}
+		fmt.Print(t)
+		return
+	}
+
 	tr := tabwriter.NewWriter(os.Stdout, 3, 2, 2, ' ', 0)
 	for i, a := range averages {
 		fmt.Fprintf(tr, "%2d.\t[%v]\t%v", i+1, a.region, a.duration)
@@ -153,6 +164,7 @@ Options:
      By default 10; can't be negative or zero.
 -t   Timeout. By default, no timeout.
      Examples: "500ms", "1s", "1s500ms".
+-top If true, only the top (non-global) region is printed.
 
 -csv CSV output; disables verbose output.
 -v   Verbose output.


### PR DESCRIPTION
Example usage:
```
$ gcloud compute regions describe $(go run ./ -top)
creationTimestamp: '1969-12-31T16:00:00.000-08:00'
description: us-east4
id: '1270'
kind: compute#region
name: us-east4
quotas:
  ...
selfLink: https://www.googleapis.com/compute/v1/projects/test-argo/regions/us-east4
status: UP
zones:
- https://www.googleapis.com/compute/v1/projects/test-argo/zones/us-east4-a
- https://www.googleapis.com/compute/v1/projects/test-argo/zones/us-east4-b
- https://www.googleapis.com/compute/v1/projects/test-argo/zones/us-east4-c
```

The `global` regioin seems fairly non-standard so I skip it as an option. It might be useful to have a mode where it prints a _zone_, but then how it selects a zone is tough (at random?)