### PR TITLE
use tabwriter to align columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,27 +26,27 @@ An example output:
 
 ```
 $ gcping
-0. [global] 17.282896ms
-1. [us-west2] 24.831978ms
-2. [us-west1] 37.200678ms
-3. [us-central1] 62.908829ms
-4. [us-east4] 76.461448ms
-5. [us-east1] 87.213011ms
-6. [northamerica-northeast1] 87.672202ms
-7. [asia-northeast1] 128.187124ms
-8. [asia-northeast2] 134.71903ms
-9. [europe-west2] 151.353133ms
-10. [europe-west1] 152.090048ms
-11. [asia-east1] 154.469779ms
-12. [europe-west4] 156.138144ms
-13. [europe-west3] 161.17031ms
-14. [australia-southeast1] 161.458364ms
-15. [asia-east2] 167.030351ms
-16. [europe-west6] 168.109585ms
-17. [southamerica-east1] 186.049558ms
-18. [europe-north1] 186.685738ms
-19. [asia-southeast1] 189.678346ms
-20. [asia-south1] 248.994198ms
+ 1.  [global]                   36.752191ms
+ 2.  [us-east4]                 37.091976ms
+ 3.  [northamerica-northeast1]  51.918669ms
+ 4.  [us-central1]              75.488941ms
+ 5.  [us-east1]                 75.928857ms
+ 6.  [us-west2]                 148.998964ms
+ 7.  [us-west1]                 157.899518ms
+ 8.  [europe-west2]             166.42703ms
+ 9.  [europe-west1]             174.226927ms
+10.  [europe-west4]             179.802812ms
+11.  [europe-west3]             195.430189ms
+12.  [europe-west6]             208.143331ms
+13.  [europe-north1]            252.823482ms
+14.  [southamerica-east1]       311.575344ms
+15.  [asia-northeast1]          338.151472ms
+16.  [asia-northeast2]          358.787403ms
+17.  [asia-east1]               394.165761ms
+18.  [asia-east2]               418.293092ms
+19.  [australia-southeast1]     425.679503ms
+20.  [asia-southeast1]          454.494659ms
+21.  [asia-south1]              573.022571ms
 ```
 
 ## Installation

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"text/tabwriter"
 	"time"
 )
 
@@ -127,13 +128,15 @@ func report() {
 	sorter := &outputSorter{averages: averages}
 	sort.Sort(sorter)
 
+	tr := tabwriter.NewWriter(os.Stdout, 3, 2, 2, ' ', 0)
 	for i, a := range averages {
-		fmt.Printf("%2d. [%v] %v", i+1, a.region, a.duration)
+		fmt.Fprintf(tr, "%2d.\t[%v]\t%v", i+1, a.region, a.duration)
 		if a.errors > 0 {
-			fmt.Printf(" (%d errors)", a.errors)
+			fmt.Fprintf(tr, "\t(%d errors)", a.errors)
 		}
-		fmt.Println()
+		fmt.Fprintln(tr)
 	}
+	tr.Flush()
 }
 
 func usage() {


### PR DESCRIPTION
Example output:

```
 1.  [global]                   34.211854ms
 2.  [us-east4]                 37.590819ms
 3.  [northamerica-northeast1]  42.284693ms
 4.  [us-east1]                 59.100263ms
 5.  [us-central1]              81.329569ms
 6.  [us-west2]                 146.524623ms
 7.  [us-west1]                 157.667834ms
 8.  [europe-west2]             165.980755ms
 9.  [europe-west1]             173.223817ms
10.  [europe-west4]             180.878582ms
11.  [europe-west3]             190.897463ms
12.  [europe-west6]             214.045302ms
13.  [europe-north1]            259.309657ms
14.  [southamerica-east1]       299.72369ms
15.  [asia-northeast1]          341.734959ms
16.  [asia-northeast2]          357.323579ms
17.  [asia-east1]               409.342538ms
18.  [australia-southeast1]     419.531276ms
19.  [asia-east2]               428.606573ms
20.  [asia-southeast1]          461.595516ms
21.  [asia-south1]              580.191125ms
```

I (briefly) tried to figure out how to align the `.`s but nothing was obvious. I admit I didn't try that hard.