### PR TITLE
 Added support for pinging individual region 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ifeq ($(origin version), undefined)
 	version := latest
-endif 
+endif
 
 release:
 	GOOS=windows GOARCH=amd64 go build -o ./bin/gcping_windows_amd64_$(version)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Options:
      By default 10; can't be negative.
 -c   Max number of requests to be made at any time.
      By default 10; can't be negative or zero.
+-r   Report latency for an individual region.
 -t   Timeout. By default, no timeout.
      Examples: "500ms", "1s", "1s500ms".
 -top If true, only the top (non-global) region is printed.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ $ gcping
 21.  [asia-south1]              573.022571ms
 ```
 
+```
+$ gcping -r us-east1
+ 1.  [us-east1]  502.068712ms
+```
+
 ## Installation
 
 * Linux 64-bit: https://storage.googleapis.com/gcping-release/gcping_linux_amd64_0.0.1

--- a/main.go
+++ b/main.go
@@ -65,6 +65,15 @@ var (
 	outputs chan output
 )
 
+// calcOutputSize calculates the actual output size.
+func calcOutputSize() int {
+	outputSize := number * len(endpoints)
+	if region != "" {
+		outputSize = number
+	}
+	return outputSize
+}
+
 func main() {
 	flag.BoolVar(&top, "top", false, "")
 	flag.IntVar(&number, "n", 10, "")
@@ -98,7 +107,8 @@ func main() {
 	go start()
 
 	inputs = make(chan input, concurrency)
-	outputs = make(chan output, number*len(endpoints))
+	outputSize := calcOutputSize()
+	outputs = make(chan output, outputSize)
 	for i := 0; i < number; i++ {
 		if region != "" {
 			e, _ := endpoints[region]
@@ -124,12 +134,7 @@ func start() {
 }
 
 func report() {
-	// Calculate the actual output size.
-	outputSize := number * len(endpoints)
-	if region != "" {
-		outputSize = number
-	}
-
+	outputSize := calcOutputSize()
 	m := make(map[string]output)
 	for i := 0; i < outputSize; i++ {
 		o := <-outputs

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 	timeout     time.Duration
 	csv         bool
 	verbose     bool
+	region      string
 	// TODO(jbd): Add payload options such as body size.
 
 	client  *http.Client // TODO(jbd): One client per worker?
@@ -71,6 +72,7 @@ func main() {
 	flag.DurationVar(&timeout, "t", time.Duration(0), "")
 	flag.BoolVar(&verbose, "v", false, "")
 	flag.BoolVar(&csv, "csv", false, "")
+	flag.StringVar(&region, "r", "", "")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -82,16 +84,29 @@ func main() {
 		verbose = false // if output is CSV, no need for verbose output
 	}
 
+	if region != "" {
+		if _, found := endpoints[region]; !found {
+			fmt.Printf("region %q is not supported or does not exist\n", region)
+			os.Exit(1)
+		}
+	}
+
 	client = &http.Client{
 		Timeout: timeout,
 	}
 
 	go start()
+
 	inputs = make(chan input, concurrency)
 	outputs = make(chan output, number*len(endpoints))
 	for i := 0; i < number; i++ {
-		for r, e := range endpoints {
-			inputs <- input{region: r, endpoint: e}
+		if region != "" {
+			e, _ := endpoints[region]
+			inputs <- input{region: region, endpoint: e}
+		} else {
+			for r, e := range endpoints {
+				inputs <- input{region: r, endpoint: e}
+			}
 		}
 	}
 	close(inputs)
@@ -109,8 +124,14 @@ func start() {
 }
 
 func report() {
+	// Calculate the actual output size.
+	outputSize := number * len(endpoints)
+	if region != "" {
+		outputSize = number
+	}
+
 	m := make(map[string]output)
-	for i := 0; i < number*len(endpoints); i++ {
+	for i := 0; i < outputSize; i++ {
 		o := <-outputs
 
 		a := m[o.region]
@@ -163,6 +184,7 @@ Options:
      By default 10; can't be negative.
 -c   Max number of requests to be made at any time.
      By default 10; can't be negative or zero.
+-r   Report latency for an individual region.
 -t   Timeout. By default, no timeout.
      Examples: "500ms", "1s", "1s500ms".
 -top If true, only the top (non-global) region is printed.


### PR DESCRIPTION
Sometime it's useful to check only a specific region, so I added support for pinging an individual region with the `-r` flag.

Examples:
```bash
    $ gcping -r us-east1
    1.  [us-east1]  502.068712ms
```
```  bash
   $ gcping -r us-beast1
   region "us-beast1" is not supported or does not exist
```

Further use-case with [sampler](https://github.com/sqshq/sampler) - see the [gcping.yml](https://github.com/dastergon/sampler-recipes/blob/master/gcping.yml) file for the config.

<img width="1422" alt="gcping-screenshot" src="https://user-images.githubusercontent.com/1192342/62834018-2b7fb380-bc47-11e9-9710-e12ee0b754d5.png">
