### PR TITLE
Added support for listing regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Google Cloud regions. It is inspired by [gcping.com](http://gcping.com).
 gcping [options...]
 
 Options:
--l	 List supported regions.
+-l   List supported regions.
 -n   Number of requests to be made to each region.
      By default 10; can't be negative.
 -c   Max number of requests to be made at any time.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Google Cloud regions. It is inspired by [gcping.com](http://gcping.com).
 gcping [options...]
 
 Options:
+-l	 List supported regions.
 -n   Number of requests to be made to each region.
      By default 10; can't be negative.
 -c   Max number of requests to be made at any time.
@@ -58,6 +59,31 @@ $ gcping -r us-east1
 
 ```
 $ gcping -top
+us-west2
+```
+
+```
+$ gcping -l
+asia-east1
+asia-east2
+asia-northeast1
+asia-northeast2
+asia-south1
+asia-southeast1
+australia-southeast1
+europe-north1
+europe-west1
+europe-west2
+europe-west3
+europe-west4
+europe-west6
+global
+northamerica-northeast1
+southamerica-east1
+us-central1
+us-east1
+us-east4
+us-west1
 us-west2
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rakyll/gcping
 
 go 1.13
+
+require github.com/google/go-cmp v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func usage() {
 var usageText = `gcping [options...]
 
 Options:
--l	 List supported regions.
+-l   List supported regions.
 -n   Number of requests to be made to each region.
      By default 10; can't be negative.
 -c   Max number of requests to be made at any time.

--- a/main.go
+++ b/main.go
@@ -23,31 +23,6 @@ import (
 	"time"
 )
 
-// TODO(jbd): Add more zones.
-var endpoints = map[string]string{
-	"global":                  "35.186.221.153",
-	"asia-east1":              "104.155.201.52",
-	"asia-east2":              "35.220.162.209",
-	"asia-northeast1":         "104.198.86.148",
-	"asia-northeast2":         "34.97.196.51",
-	"asia-south1":             "35.200.186.152",
-	"asia-southeast1":         "35.185.179.198",
-	"australia-southeast1":    "35.189.6.113",
-	"europe-north1":           "35.228.170.201",
-	"europe-west1":            "104.199.82.109",
-	"europe-west2":            "35.189.67.146",
-	"europe-west3":            "35.198.78.172",
-	"europe-west4":            "35.204.93.82",
-	"europe-west6":            "34.65.3.254",
-	"northamerica-northeast1": "35.203.57.164",
-	"southamerica-east1":      "35.198.10.68",
-	"us-central1":             "104.197.165.8",
-	"us-east1":                "104.196.161.21",
-	"us-east4":                "35.186.168.152",
-	"us-west1":                "104.199.116.74",
-	"us-west2":                "35.236.45.25",
-}
-
 var (
 	top         bool
 	number      int // number of requests for each region
@@ -56,6 +31,7 @@ var (
 	csv         bool
 	verbose     bool
 	region      string
+	list        bool
 	// TODO(jbd): Add payload options such as body size.
 
 	client *http.Client // TODO(jbd): One client per worker?
@@ -64,6 +40,7 @@ var (
 func main() {
 	flag.IntVar(&concurrency, "c", 10, "")
 	flag.BoolVar(&csv, "csv", false, "")
+	flag.BoolVar(&list, "l", false, "")
 	flag.IntVar(&number, "n", 10, "")
 	flag.StringVar(&region, "r", "", "")
 	flag.DurationVar(&timeout, "t", time.Duration(0), "")
@@ -78,6 +55,14 @@ func main() {
 	}
 	if csv {
 		verbose = false // if output is CSV, no need for verbose output
+	}
+
+	if list {
+		regions := getSortedRegions()
+		for _, region := range regions {
+			fmt.Println(region)
+		}
+		os.Exit(0)
 	}
 
 	if region != "" {
@@ -112,6 +97,7 @@ func usage() {
 var usageText = `gcping [options...]
 
 Options:
+-l	 List supported regions.
 -n   Number of requests to be made to each region.
      By default 10; can't be negative.
 -c   Max number of requests to be made at any time.

--- a/main.go
+++ b/main.go
@@ -62,13 +62,13 @@ var (
 )
 
 func main() {
-	flag.BoolVar(&top, "top", false, "")
-	flag.IntVar(&number, "n", 10, "")
 	flag.IntVar(&concurrency, "c", 10, "")
-	flag.DurationVar(&timeout, "t", time.Duration(0), "")
-	flag.BoolVar(&verbose, "v", false, "")
 	flag.BoolVar(&csv, "csv", false, "")
+	flag.IntVar(&number, "n", 10, "")
 	flag.StringVar(&region, "r", "", "")
+	flag.DurationVar(&timeout, "t", time.Duration(0), "")
+	flag.BoolVar(&top, "top", false, "")
+	flag.BoolVar(&verbose, "v", false, "")
 
 	flag.Usage = usage
 	flag.Parse()

--- a/regions.go
+++ b/regions.go
@@ -1,0 +1,38 @@
+package main
+
+import "sort"
+
+// TODO(jbd): Add more zones.
+var endpoints = map[string]string{
+	"global":                  "35.186.221.153",
+	"asia-east1":              "104.155.201.52",
+	"asia-east2":              "35.220.162.209",
+	"asia-northeast1":         "104.198.86.148",
+	"asia-northeast2":         "34.97.196.51",
+	"asia-south1":             "35.200.186.152",
+	"asia-southeast1":         "35.185.179.198",
+	"australia-southeast1":    "35.189.6.113",
+	"europe-north1":           "35.228.170.201",
+	"europe-west1":            "104.199.82.109",
+	"europe-west2":            "35.189.67.146",
+	"europe-west3":            "35.198.78.172",
+	"europe-west4":            "35.204.93.82",
+	"europe-west6":            "34.65.3.254",
+	"northamerica-northeast1": "35.203.57.164",
+	"southamerica-east1":      "35.198.10.68",
+	"us-central1":             "104.197.165.8",
+	"us-east1":                "104.196.161.21",
+	"us-east4":                "35.186.168.152",
+	"us-west1":                "104.199.116.74",
+	"us-west2":                "35.236.45.25",
+}
+
+// getSortedRegions sorts and returns a list of regions.
+func getSortedRegions() []string {
+	regions := make([]string, 0, len(endpoints))
+	for region := range endpoints {
+		regions = append(regions, region)
+	}
+	sort.Strings(regions) //sort regions alphabetically.
+	return regions
+}

--- a/regions_test.go
+++ b/regions_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetSortedRegions(t *testing.T) {
+	tests := []struct {
+		name string
+		want []string
+	}{
+		{
+			name: "successfully sorted region list",
+			want: []string{"asia-east1", "asia-east2", "asia-northeast1", "asia-northeast2", "asia-south1", "asia-southeast1", "australia-southeast1", "europe-north1", "europe-west1", "europe-west2", "europe-west3", "europe-west4", "europe-west6", "global", "northamerica-northeast1", "southamerica-east1", "us-central1", "us-east1", "us-east4", "us-west1", "us-west2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getSortedRegions()
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("getSortedRegions returned unexpected output (-got +want):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces the `-l` flag to list currently supported regions by `gcping`. It's a two column output that shows the name of region and its respective physical location (city & country). I believe showing a region's physical location gives a bit of context in regards to the results of gcping. It also saves us from opening a browser tab to find that information. The physical locations are unlikely to change, so I hardcoded the names in the source code.

Example output:
```
$ gcping -l
asia-east1
asia-east2
asia-northeast1
asia-northeast2
asia-south1
asia-southeast1
australia-southeast1
europe-north1
europe-west1
europe-west2
europe-west3
europe-west4
europe-west6
global
northamerica-northeast1
southamerica-east1
us-central1
us-east1
us-east4
us-west1
us-west2
```