### PR TITLE
Reworked pingserver routes and added test cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rakyll/gcping
 
 go 1.13
+
+require github.com/google/go-cmp v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/pingserver/main.go
+++ b/pingserver/main.go
@@ -20,7 +20,7 @@ import (
 	"os"
 )
 
-// greetHandler responds with an HTTP 200 status code and a message when the service is running.
+// greetHandler handles the index page.
 func greetHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		http.NotFound(w, r)
@@ -31,14 +31,14 @@ func greetHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("hello"))
 }
 
-// pingHandler responds with an HTTP 200 status code and a message when the service is running.
+// pingHandler handles the ping-pong interaction.
 func pingHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "text/plain")
 	w.Write([]byte("pong"))
 }
 
-// setupHandlers sets the routes for the server.
+// setupHandlers configures the routes for the server.
 func setupHandlers() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", greetHandler)

--- a/pingserver/main.go
+++ b/pingserver/main.go
@@ -15,19 +15,43 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
 )
 
+// greetHandler responds with an HTTP 200 status code and a message when the service is running.
+func greetHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte("hello"))
+}
+
+// pingHandler responds with an HTTP 200 status code and a message when the service is running.
+func pingHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte("pong"))
+}
+
+// setupHandlers sets the routes for the server.
+func setupHandlers() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", greetHandler)
+	mux.HandleFunc("/ping", pingHandler)
+	return mux
+}
+
 func main() {
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "hello")
-	})
+	mux := setupHandlers()
 	port := os.Getenv("PORT") // makes it portable to Cloud Run
 	if port == "" {
 		port = "80"
 	}
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	log.Printf("Server listening on *:%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, mux))
 }

--- a/pingserver/main_test.go
+++ b/pingserver/main_test.go
@@ -1,0 +1,136 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGreetHandler(t *testing.T) {
+	tests := []struct {
+		name string
+		want []byte
+	}{
+		{
+			name: "successful greet",
+			want: []byte("hello"),
+		},
+	}
+
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler := http.HandlerFunc(greetHandler)
+			handler.ServeHTTP(w, r)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Unexpected status code %d", resp.StatusCode)
+			}
+
+			if diff := cmp.Diff(w.Body.Bytes(), tt.want); diff != "" {
+				t.Errorf("greetHandler returned unexpected body (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPingHandler(t *testing.T) {
+	tests := []struct {
+		name string
+		want []byte
+	}{
+		{
+			name: "successful ping",
+			want: []byte("pong"),
+		},
+	}
+
+	r, err := http.NewRequest(http.MethodGet, "/ping", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler := http.HandlerFunc(pingHandler)
+			handler.ServeHTTP(w, r)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Unexpected status code %d", resp.StatusCode)
+			}
+
+			if diff := cmp.Diff(w.Body.Bytes(), tt.want); diff != "" {
+				t.Errorf("pingHandler returned unexpected body (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetupHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		endpoint       string
+		wantStatusCode int
+	}{
+		{
+			name:           "successful greet - HTTP 200",
+			endpoint:       "/",
+			wantStatusCode: 200,
+		},
+		{
+			name:           "successful ping - HTTP 200",
+			endpoint:       "/ping",
+			wantStatusCode: 200,
+		},
+		{
+			name:           "wrong endpoint - HTTP 404",
+			endpoint:       "/foobar",
+			wantStatusCode: 404,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, err := http.NewRequest(http.MethodGet, tc.endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			w := httptest.NewRecorder()
+			handler := setupHandlers()
+			handler.ServeHTTP(w, r)
+
+			resp := w.Result()
+			if resp.StatusCode != tc.wantStatusCode {
+				t.Errorf("Unexpected status code %d", resp.StatusCode)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
At the source code for the worker (https://github.com/GoogleCloudPlatform/gcping/blob/master/worker.go#L33), endpoint `/ping` is requested, but `pingserver` didn't have an explicit mention for `/ping`. I extended the `pingserver` code a bit and added a few test cases. 

We could readjust the routes, if you'd like to keep it more minimal. 