### PR TITLE
Add -reportcsv

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 	concurrency int
 	timeout     time.Duration
 	csv         bool
+	reportcsv   bool
 	verbose     bool
 	region      string
 	// TODO(jbd): Add payload options such as body size.
@@ -68,6 +69,7 @@ func main() {
 	flag.DurationVar(&timeout, "t", time.Duration(0), "")
 	flag.BoolVar(&verbose, "v", false, "")
 	flag.BoolVar(&csv, "csv", false, "")
+	flag.BoolVar(&reportcsv, "reportcsv", false, "")
 	flag.StringVar(&region, "r", "", "")
 
 	flag.Usage = usage
@@ -99,6 +101,8 @@ func main() {
 		w.reportRegion(region)
 	case top:
 		w.reportTop()
+	case reportcsv:
+		w.reportCSV()
 	default:
 		w.reportAll()
 	}
@@ -112,17 +116,18 @@ func usage() {
 var usageText = `gcping [options...]
 
 Options:
--n   Number of requests to be made to each region.
-     By default 10; can't be negative.
--c   Max number of requests to be made at any time.
-     By default 10; can't be negative or zero.
--r   Report latency for an individual region.
--t   Timeout. By default, no timeout.
-     Examples: "500ms", "1s", "1s500ms".
--top If true, only the top (non-global) region is printed.
+-n         Number of requests to be made to each region.
+           By default 10; can't be negative.
+-c         Max number of requests to be made at any time.
+           By default 10; can't be negative or zero.
+-r         Report latency for an individual region.
+-t         Timeout. By default, no timeout.
+           Examples: "500ms", "1s", "1s500ms".
+-top       If true, only the top (non-global) region is printed.
+-reportcsv report in CSV format; disables default report.
 
--csv CSV output; disables verbose output.
--v   Verbose output.
+-csv       CSV output; disables verbose output.
+-v         Verbose output.
 
 Need a website version? See gcping.com
 `

--- a/worker.go
+++ b/worker.go
@@ -153,6 +153,23 @@ func (w *worker) reportAll() {
 	tr.Flush()
 }
 
+func (w *worker) reportCSV() {
+	w.inputs = make(chan input, concurrency)
+	w.outputs = make(chan output, w.size(region))
+	for i := 0; i < number; i++ {
+		for r, e := range endpoints {
+			w.inputs <- input{region: r, endpoint: e}
+		}
+	}
+	close(w.inputs)
+
+	sorted := w.sortOutput()
+	fmt.Println("region,latency_ns,errors")
+	for _, a := range sorted {
+		fmt.Printf("%v,%v,%v\n", a.region, a.median().Nanoseconds(), a.errors)
+	}
+}
+
 func (w *worker) reportTop() {
 	w.inputs = make(chan input, concurrency)
 	w.outputs = make(chan output, w.size(region))


### PR DESCRIPTION
I want to add flag `-reportcsv` to emit report as CSV.

Because:
- `-csv` option is raw value so too verbose
- `time.Duration` format is not fixed suffix and parsing is not trivial

It works as below:

```
region,latency_ns,errors
asia-northeast1,11730791,0
global,13893030,0
asia-northeast2,26818270,0
asia-east1,88615403,0
asia-east2,116482288,0
asia-southeast1,145251425,0
us-west2,215389864,0
us-west1,221996919,0
australia-southeast1,238973041,0
asia-south1,264341028,0
us-central1,278920187,0
us-east4,331633530,0
us-east1,332646787,0
northamerica-northeast1,344326231,0
europe-west2,463623402,0
europe-west1,478584126,0
europe-west4,480959888,0
europe-west3,488298014,0
europe-west6,503636179,0
southamerica-east1,540515983,0
europe-north1,542399947,0
```

Note: I have used gcping to measure inter-region latencies.
https://gist.github.com/apstndb/5bc25193c7349e5d70dc8599dc3805cb