### PR TITLE
go.mod: fix module name to github.com/GoogleCloudPlatform/gcping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rakyll/gcping
+module github.com/GoogleCloudPlatform/gcping
 
 go 1.13


### PR DESCRIPTION
Fix module name to `github.com/GoogleCloudPlatform/gcping` :P

@rakyll Thanks for develop the awesome tools!