### PR TITLE
Update GitHub link and fix typo

### DIFF
--- a/cmd/ping/kodata/index.html
+++ b/cmd/ping/kodata/index.html
@@ -197,7 +197,7 @@ p {
           conditions. Results are not scientific.</p>
           <p>This is not an official Google project.
           <a target="_blank"
-             href="https://github.com/imjasonh/gcping">Source available on GitHub</a>.</p>
+             href="https://github.com/GoogleCloudPlatform/gcping">Source available on GitHub</a>.</p>
         </div>
       </div>
     </main>

--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -131,7 +131,7 @@ var AllEndpoints = map[string]Endpoint{
 	"us-east4": {
 		URL:        "https://us-east4-5tkroniexa-uk.a.run.app",
 		Region:     "us-east4",
-		RegionName: "N. Virgina",
+		RegionName: "North Virginia",
 	},
 	"us-west1": {
 		URL:        "https://us-west1-5tkroniexa-uw.a.run.app",


### PR DESCRIPTION
"North Virginia" is more consistent with "South Carolina", unless you'd prefer to have that be "S. Carolina" instead. 🤷 