### PR TITLE
Ignore metadata changes by Cloud Run API to sandbox

### DIFF
--- a/gcping.tf
+++ b/gcping.tf
@@ -81,8 +81,6 @@ resource "google_cloud_run_service" "regions" {
       annotations = {
         "autoscaling.knative.dev/maxScale" = "3" // Control costs.
         "run.googleapis.com/launch-stage"  = "BETA"
-        // This gets added and causes diffs, but must be removed before adding a new service...
-        // "run.googleapis.com/sandbox"       = "gvisor"
       }
     }
     spec {


### PR DESCRIPTION
Ignore metadata changes to run.googleapis.com/sandbox set by Cloud Run API after deployments.