### PR TITLE
Append new line after cli output

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -187,7 +187,7 @@ func (w *worker) reportTop() {
 	if t == "global" {
 		t = sorted[1].region
 	}
-	fmt.Print(t)
+	fmt.Println(t )
 	return
 }
 
@@ -201,7 +201,7 @@ func (w *worker) reportRegion(region string) {
 	close(w.inputs)
 
 	sorted := w.sortOutput()
-	fmt.Print(sorted[0].median())
+	fmt.Println(sorted[0].median())
 
 }
 


### PR DESCRIPTION
Fixes cli output from:

```
~/gcping $ gcping -r us-east1
228.653651ms~/gcping $
```

to
```
~/gcping $ gcping -r us-east1
228.653651ms
~/gcping $
```