### PR TITLE
Update product name

### DIFF
--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -30,7 +30,7 @@ var AllEndpoints = map[string]Endpoint{
 	"global": {
 		URL:        "https://global.gcping.com",
 		Region:     "global",
-		RegionName: "Global HTTP Load Balancer",
+		RegionName: "Global External HTTPS Load Balancer",
 	},
 	"asia-east1": {
 		URL:        "https://asia-east1-5tkroniexa-de.a.run.app",

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -196,9 +196,9 @@
                     The <b>global</b> row uses a
                     <a
                       target="_blank"
-                      href="https://cloud.google.com/load-balancing/"
+                      href="https://cloud.google.com/load-balancing"
                       ><i class="material-icons" aria-hidden="true">link</i>
-                      Global HTTPS Load Balancer</a
+                      Global External HTTPS Load Balancer</a
                     >
                     to route requests to the nearest service.
                   </p>


### PR DESCRIPTION
Hi, 

Sorry for the noise but I wanted to make sure the product name of the global External HTTPS Load Balancer is consistent with how the docs call it...

https://cloud.google.com/load-balancing/docs/https

Best, 
Wietse