### PR TITLE
make cli use /api/endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ Note: This is not an official Google product.
 gcping [options...]
 
 Options:
--n   Number of requests to be made to each region.
-     By default 10; can't be negative.
--c   Max number of requests to be made at any time.
-     By default 10; can't be negative or zero.
--r   Report latency for an individual region.
--t   Timeout. By default, no timeout.
-     Examples: "500ms", "1s", "1s500ms".
--top If true, only the top (non-global) region is printed.
+-n       Number of requests to be made to each region.
+         By default 10; can't be negative.
+-c       Max number of requests to be made at any time.
+         By default 10; can't be negative or zero.
+-r       Report latency for an individual region.
+-t       Timeout. By default, no timeout.
+         Examples: "500ms", "1s", "1s500ms".
+-top     If true, only the top (non-global) region is printed.
+-csv-cum If true, cumulative value is printed in CSV; disables default report.
+-url     URL of endpoint list. Default is https://global.gcping.com/api/endpoints
 
--csv CSV output; disables verbose output.
--v   Verbose output.
+-csv     CSV output; disables verbose output.
+-v       Verbose output.
 
 Need a website version? See gcping.com
 ```

--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -32,11 +32,9 @@ type Endpoint struct {
 	RegionName string
 }
 
-// GetEndpointsFromServer is used by the cli to generate an Endpoint map
+// EndpointsFromServer is used by the cli to generate an Endpoint map
 // using json served by the gcping endpoints.
-func GetEndpointsFromServer(ctx context.Context, endpointsURL string) (map[string]Endpoint, error) {
-
-	endpointsMap := make(map[string]Endpoint)
+func EndpointsFromServer(ctx context.Context, endpointsURL string) (map[string]Endpoint, error) {
 
 	req, err := http.NewRequestWithContext(
 		ctx,
@@ -48,18 +46,20 @@ func GetEndpointsFromServer(ctx context.Context, endpointsURL string) (map[strin
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		err := fmt.Errorf("%v %s", resp.Status, endpointsURL)
 		return nil, err
 	}
 
-	defer resp.Body.Close()
+	e := make(map[string]Endpoint)
 	decoder := json.NewDecoder(resp.Body)
-	if err := decoder.Decode(&endpointsMap); err != nil {
-		return endpointsMap, err
+	if err := decoder.Decode(&e); err != nil {
+		return e, err
 	}
 
-	return endpointsMap, err
+	return e, err
 }
 
 // AllEndpoints associates a region name with its Cloud Run Endpoint.

--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -42,6 +42,9 @@ func EndpointsFromServer(ctx context.Context, endpointsURL string) (map[string]E
 		endpointsURL,
 		nil,
 	)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -49,8 +52,7 @@ func EndpointsFromServer(ctx context.Context, endpointsURL string) (map[string]E
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("%v %s", resp.Status, endpointsURL)
-		return nil, err
+		return nil, fmt.Errorf("%v %s", resp.Status, endpointsURL)
 	}
 
 	e := make(map[string]Endpoint)

--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -177,6 +177,11 @@ var AllEndpoints = map[string]Endpoint{
 		Region:     "us-east5",
 		RegionName: "Columbus",
 	},
+	"us-south1": {
+		URL:        "https://us-south1-5tkroniexa-vp.a.run.app/",
+		Region:     "us-south1",
+		RegionName: "Dallas",
+	},
 	"us-west1": {
 		URL:        "https://us-west1-5tkroniexa-uw.a.run.app",
 		Region:     "us-west1",

--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -44,14 +44,13 @@ func GetEndpointsFromServer(ctx context.Context, endpointsURL string) (map[strin
 		endpointsURL,
 		nil,
 	)
-	client := http.DefaultClient
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return endpointsMap, err
+		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
 		err := fmt.Errorf("%v %s", resp.Status, endpointsURL)
-		return endpointsMap, err
+		return nil, err
 	}
 
 	defer resp.Body.Close()

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	// Fetch and cache endpoint map in memory for the duration of the
 	// process.
-	endpoints, err := config.GetEndpointsFromServer(ctx, endpointsURL)
+	endpoints, err := config.EndpointsFromServer(ctx, endpointsURL)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Fetch and cache endpoint map in memory for the duration of the

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -26,14 +27,15 @@ import (
 )
 
 var (
-	top         bool
-	number      int // number of requests for each region
-	concurrency int
-	timeout     time.Duration
-	csv         bool
-	csvCum      bool
-	verbose     bool
-	region      string
+	top          bool
+	number       int // number of requests for each region
+	concurrency  int
+	timeout      time.Duration
+	csv          bool
+	csvCum       bool
+	verbose      bool
+	region       string
+	endpointsURL string
 	// TODO(jbd): Add payload options such as body size.
 
 	client *http.Client // TODO(jbd): One client per worker?
@@ -48,9 +50,21 @@ func main() {
 	flag.BoolVar(&csv, "csv", false, "")
 	flag.BoolVar(&csvCum, "csv-cum", false, "")
 	flag.StringVar(&region, "r", "", "")
+	flag.StringVar(&endpointsURL, "url", "https://global.gcping.com/api/endpoints", "")
 
 	flag.Usage = usage
 	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+	defer cancel()
+
+	// Fetch and cache endpoint map in memory for the duration of the
+	// process.
+	endpoints, err := config.GetEndpointsFromServer(ctx, endpointsURL)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	if number < 0 || concurrency <= 0 {
 		usage()
@@ -60,7 +74,7 @@ func main() {
 	}
 
 	if region != "" {
-		if _, found := config.AllEndpoints[region]; !found {
+		if _, found := endpoints[region]; !found {
 			fmt.Printf("region %q is not supported or does not exist\n", region)
 			os.Exit(1)
 		}
@@ -75,13 +89,13 @@ func main() {
 
 	switch {
 	case region != "":
-		w.reportRegion(region)
+		w.reportRegion(endpoints, region)
 	case top:
-		w.reportTop()
+		w.reportTop(endpoints)
 	case csvCum:
-		w.reportCSV()
+		w.reportCSV(endpoints)
 	default:
-		w.reportAll()
+		w.reportAll(endpoints)
 	}
 }
 
@@ -102,6 +116,7 @@ Options:
          Examples: "500ms", "1s", "1s500ms".
 -top     If true, only the top (non-global) region is printed.
 -csv-cum If true, cumulative value is printed in CSV; disables default report.
+-url     URL of endpoint list. Default is https://global.gcping.com/api/endpoints
 
 -csv     CSV output; disables verbose output.
 -v       Verbose output.

--- a/regions.json
+++ b/regions.json
@@ -28,6 +28,7 @@
     "us-east1": "South Carolina",
     "us-east4": "North Virginia",
     "us-east5": "Columbus",
+    "us-south1": "Dallas",
     "us-west1": "Oregon",
     "us-west2": "Los Angeles",
     "us-west3": "Salt Lake City",

--- a/worker.go
+++ b/worker.go
@@ -108,9 +108,9 @@ func (w *worker) start() {
 	}
 }
 
-func (w *worker) sortOutput() []output {
+func (w *worker) sortOutput(em map[string]config.Endpoint) []output {
 	m := make(map[string]output)
-	for i := 0; i < w.size(region); i++ {
+	for i := 0; i < w.size(em, region); i++ {
 		o := <-w.outputs
 
 		a := m[o.region]
@@ -133,17 +133,17 @@ func (w *worker) sortOutput() []output {
 	return all
 }
 
-func (w *worker) reportAll() {
+func (w *worker) reportAll(em map[string]config.Endpoint) {
 	w.inputs = make(chan input, concurrency)
-	w.outputs = make(chan output, w.size(region))
+	w.outputs = make(chan output, w.size(em, region))
 	for i := 0; i < number; i++ {
-		for r, e := range config.AllEndpoints {
+		for r, e := range em {
 			w.inputs <- input{region: r, endpoint: e.URL}
 		}
 	}
 	close(w.inputs)
 
-	sorted := w.sortOutput()
+	sorted := w.sortOutput(em)
 	tr := tabwriter.NewWriter(os.Stdout, 3, 2, 2, ' ', 0)
 	for i, a := range sorted {
 		fmt.Fprintf(tr, "%2d.\t[%v]\t%v", i+1, a.region, a.median())
@@ -155,59 +155,58 @@ func (w *worker) reportAll() {
 	tr.Flush()
 }
 
-func (w *worker) reportCSV() {
+func (w *worker) reportCSV(em map[string]config.Endpoint) {
 	w.inputs = make(chan input, concurrency)
-	w.outputs = make(chan output, w.size(region))
+	w.outputs = make(chan output, w.size(em, region))
 	for i := 0; i < number; i++ {
-		for r, e := range config.AllEndpoints {
+		for r, e := range em {
 			w.inputs <- input{region: r, endpoint: e.URL}
 		}
 	}
 	close(w.inputs)
 
-	sorted := w.sortOutput()
+	sorted := w.sortOutput(em)
 	fmt.Println("region,latency_ns,errors")
 	for _, a := range sorted {
 		fmt.Printf("%v,%v,%v\n", a.region, a.median().Nanoseconds(), a.errors)
 	}
 }
 
-func (w *worker) reportTop() {
+func (w *worker) reportTop(em map[string]config.Endpoint) {
 	w.inputs = make(chan input, concurrency)
-	w.outputs = make(chan output, w.size(region))
+	w.outputs = make(chan output, w.size(em, region))
 	for i := 0; i < number; i++ {
-		for r, e := range config.AllEndpoints {
+		for r, e := range em {
 			w.inputs <- input{region: r, endpoint: e.URL}
 		}
 	}
 	close(w.inputs)
 
-	sorted := w.sortOutput()
+	sorted := w.sortOutput(em)
 	t := sorted[0].region
 	if t == "global" {
 		t = sorted[1].region
 	}
-	fmt.Println(t )
+	fmt.Println(t)
 	return
 }
 
-func (w *worker) reportRegion(region string) {
+func (w *worker) reportRegion(em map[string]config.Endpoint, region string) {
 	w.inputs = make(chan input, concurrency)
-	w.outputs = make(chan output, w.size(region))
+	w.outputs = make(chan output, w.size(em, region))
 	for i := 0; i < number; i++ {
-		e, _ := config.AllEndpoints[region]
+		e, _ := em[region]
 		w.inputs <- input{region: region, endpoint: e.URL}
 	}
 	close(w.inputs)
 
-	sorted := w.sortOutput()
+	sorted := w.sortOutput(em)
 	fmt.Println(sorted[0].median())
-
 }
 
-func (w *worker) size(region string) int {
+func (w *worker) size(em map[string]config.Endpoint, region string) int {
 	if region != "" {
 		return number
 	}
-	return number * len(config.AllEndpoints)
+	return number * len(em)
 }


### PR DESCRIPTION
The `gcping` cli currently uses a static endpoint map `AllEndpoints` which is embedded in the cli. This forces a cli release everytime a new region is added.

This change makes the cli fetch an endpoint map at runtime from `/api/endpoints` instead of using the embedded config.

By default, the cli uses https://global.gcping.com/api/endpoints and the endpoint map URL is configurable using the `--url` flag, e.g:
`gcping --url https://example.com/api/endpoints`