### PR TITLE
use endpoints list from gcs

### DIFF
--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -32,6 +32,7 @@ type Endpoint struct {
 	RegionName string
 }
 
+// TODO: clean up after PR#138 is merged and tested https://github.com/GoogleCloudPlatform/gcping/pull/138
 // EndpointsFromServer is used by the cli to generate an Endpoint map
 // using json served by the gcping endpoints.
 func EndpointsFromServer(ctx context.Context, endpointsURL string) (map[string]Endpoint, error) {

--- a/internal/httphandler/httphandler.go
+++ b/internal/httphandler/httphandler.go
@@ -49,7 +49,9 @@ func New(opts *Options) *Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.StaticHandler())
 
+	// TODO: clean up after PR#138 is merged and tested https://github.com/GoogleCloudPlatform/gcping/pull/138
 	mux.HandleFunc("/api/endpoints", s.HandleEndpoints)
+
 	mux.HandleFunc("/api/ping", s.HandlePing)
 
 	// Serve /ping with region response to fix issue#96 on older cli versions.

--- a/tools/terraform/endpoints_gcs_object.tf
+++ b/tools/terraform/endpoints_gcs_object.tf
@@ -15,8 +15,7 @@
 
 // Create a bucket for CLI releases
 resource "google_storage_bucket_object" "endpoints_config" {
-  // TODO: set path to /api/endpoints once LB url maps and configs validated
-  name         = "api/gcs-endpoints"
+  name         = "api/endpoints"
   bucket       = google_storage_bucket.config.id
   content_type = "application/json"
 

--- a/tools/terraform/networking.tf
+++ b/tools/terraform/networking.tf
@@ -91,8 +91,7 @@ resource "google_compute_url_map" "global" {
     default_service = google_compute_backend_service.global.self_link
 
     path_rule {
-      // TODO: set path to /api/endpoints once LB url maps and configs validated
-      paths   = ["/api/gcs-endpoints"]
+      paths   = ["/api/endpoints"]
       service = google_compute_backend_bucket.endpoints_backend.id
     }
   }
@@ -115,19 +114,19 @@ resource "google_compute_url_map" "global" {
   test {
     service = google_compute_backend_bucket.endpoints_backend.id
     host    = var.domain
-    path    = "/api/gcs-endpoints"
+    path    = "/api/endpoints"
   }
 
   test {
     service = google_compute_backend_bucket.endpoints_backend.id
     host    = "www.${var.domain}"
-    path    = "/api/gcs-endpoints"
+    path    = "/api/endpoints"
   }
 
   test {
     service = google_compute_backend_bucket.endpoints_backend.id
     host    = "global.${var.domain}"
-    path    = "/api/gcs-endpoints"
+    path    = "/api/endpoints"
   }
 
   test {


### PR DESCRIPTION
this is a follow up to https://github.com/GoogleCloudPlatform/gcping/pull/136

This PR will expose the endpoints list served by GCS through the URL https://gcping.com/api/endpoints instead of https://gcping.com/api/gcs-endpoints, thus making it live for the frontends (cli and web app).

Also added TODOs to clean-up the Go functions that currently serve the static endpoint config under /api/endpoint