### PR TITLE
lock node builder image to node:18

### DIFF
--- a/tools/cloudbuild/deploy.yaml
+++ b/tools/cloudbuild/deploy.yaml
@@ -15,12 +15,12 @@
 logsBucket: "gs://${PROJECT_ID}_gcblogs"
 
 steps:
-- name: 'node'
+- name: 'node:18'
   id: npm-install
   entrypoint: 'npm'
   args: ['install', 'web/']
 
-- name: 'node'
+- name: 'node:18'
   id: npm-build
   entrypoint: 'npm'
   args: ['--prefix', 'web/', 'run', 'build']

--- a/tools/cloudbuild/deploy.yaml
+++ b/tools/cloudbuild/deploy.yaml
@@ -15,12 +15,12 @@
 logsBucket: "gs://${PROJECT_ID}_gcblogs"
 
 steps:
-- name: 'node:18'
+- name: 'node:19.1'
   id: npm-install
   entrypoint: 'npm'
   args: ['install', 'web/']
 
-- name: 'node:18'
+- name: 'node:19.1'
   id: npm-build
   entrypoint: 'npm'
   args: ['--prefix', 'web/', 'run', 'build']

--- a/tools/cloudbuild/pr-open.yaml
+++ b/tools/cloudbuild/pr-open.yaml
@@ -15,12 +15,12 @@
 logsBucket: "gs://${PROJECT_ID}_gcblogs"
 
 steps:
-- name: 'node'
+- name: 'node:18'
   id: npm-install
   entrypoint: 'npm'
   args: ['install', 'web/']
 
-- name: 'node'
+- name: 'node:18'
   id: npm-build
   entrypoint: 'npm'
   args: ['--prefix', 'web/', 'run', 'build']

--- a/tools/cloudbuild/pr-open.yaml
+++ b/tools/cloudbuild/pr-open.yaml
@@ -15,12 +15,12 @@
 logsBucket: "gs://${PROJECT_ID}_gcblogs"
 
 steps:
-- name: 'node:18'
+- name: 'node:19.1'
   id: npm-install
   entrypoint: 'npm'
   args: ['install', 'web/']
 
-- name: 'node:18'
+- name: 'node:19.1'
   id: npm-build
   entrypoint: 'npm'
   args: ['--prefix', 'web/', 'run', 'build']


### PR DESCRIPTION
We are currently tracking `node:latest`; the latest release seems to be breaking our npm builds.
Locking node to `node:18` instead.
