### PR TITLE
remove deprecated HandleEndpoints http handler

### DIFF
--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -32,7 +32,6 @@ type Endpoint struct {
 	RegionName string
 }
 
-// TODO: clean up after PR#138 is merged and tested https://github.com/GoogleCloudPlatform/gcping/pull/138
 // EndpointsFromServer is used by the cli to generate an Endpoint map
 // using json served by the gcping endpoints.
 func EndpointsFromServer(ctx context.Context, endpointsURL string) (map[string]Endpoint, error) {

--- a/internal/httphandler/httphandler.go
+++ b/internal/httphandler/httphandler.go
@@ -15,7 +15,6 @@
 package httphandler
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -49,9 +48,6 @@ func New(opts *Options) *Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.StaticHandler())
 
-	// TODO: clean up after PR#138 is merged and tested https://github.com/GoogleCloudPlatform/gcping/pull/138
-	mux.HandleFunc("/api/endpoints", s.HandleEndpoints)
-
 	mux.HandleFunc("/api/ping", s.HandlePing)
 
 	// Serve /ping with region response to fix issue#96 on older cli versions.
@@ -72,15 +68,6 @@ func (s *Handler) StaticHandler() http.HandlerFunc {
 		// TODO: add HTST header to static files.
 		// addHTSTHeader(w)
 		h.ServeHTTP(w, r)
-	}
-}
-
-// HandleEndpoints returns a list of available endpoints as JSON.
-func (s *Handler) HandleEndpoints(w http.ResponseWriter, r *http.Request) {
-	addHeaders(w)
-	w.Header().Add("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(s.Endpoints); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 

--- a/internal/httphandler/httphandler_test.go
+++ b/internal/httphandler/httphandler_test.go
@@ -15,7 +15,6 @@
 package httphandler
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -25,39 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/gcping/internal/config"
 	"github.com/google/go-cmp/cmp"
 )
-
-func TestEndpoints(t *testing.T) {
-	t.Parallel()
-
-	handler := New(&Options{Endpoints: config.AllEndpoints})
-	req := httptest.NewRequest(http.MethodGet, "https://gcping.com/api/endpoints", nil)
-	w := httptest.NewRecorder()
-	handler.HandleEndpoints(w, req)
-	resp := w.Result()
-	t.Cleanup(func() { resp.Body.Close() })
-	wantHeader := http.Header{
-		"Content-Type":                {"application/json"},
-		"Cache-Control":               {"no-store"},
-		"Access-Control-Allow-Origin": {"*"},
-		"Strict-Transport-Security":   {"max-age=3600; includeSubdomains; preload"},
-	}
-
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Errorf("HandleEndpoints() Status Code: got %v, want %v", got, want)
-	}
-	if diff := cmp.Diff(wantHeader, resp.Header); diff != "" {
-		t.Errorf("HandleEndpoiints() Header (-want, +got):\n%s", diff)
-	}
-
-	var got map[string]config.Endpoint
-	err := json.NewDecoder(resp.Body).Decode(&got)
-	if err != nil {
-		t.Errorf("Failed to decode JSON: %v", err)
-	}
-	if diff := cmp.Diff(config.AllEndpoints, got); diff != "" {
-		t.Errorf("HandleEndpoints() = (-want, +got):\n%s", diff)
-	}
-}
 
 func TestPing(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
As of #138, The endpoint list at https://gcping.com/api/endpoints is now getting served from GCS, backed by CDN.
I'm removing the HTTP HandleEndpoints http handlers as they are no longer used.