### PR TITLE
Update GitHub Actions for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,36 +15,34 @@
 name: Tests
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   go:
     name: Go
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
-      with:
-        go-version: 'stable'
-    - name: Build
-      run: go build -v ./...
-    - name: Test
-      run: go test -v ./...
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: stable
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./...
   node:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 22
-    - name: Run lint
-      run: |
-        npm ci
-        npm run lint
-      working-directory: web
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Run lint
+        run: |
+          npm ci
+          npm run lint
+        working-directory: web
   terraform:
     runs-on: ubuntu-latest
     defaults:
@@ -60,4 +58,5 @@ jobs:
         run: terraform init -backend=false -input=false
       - name: terraform validate
         run: terraform validate -no-color
-  
+permissions:
+  contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,33 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CLI Build
+name: Tests
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
 jobs:
-  build:
+  go:
+    name: Go
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
       with:
-        go-version: ^1.19.3
+        go-version: 'stable'
     - name: Build
       run: go build -v ./...
     - name: Test
       run: go test -v ./...
-  lint:
+  node:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
     - name: Run lint
       run: |
-        cd web
         npm ci
         npm run lint
+      working-directory: web
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/terraform
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - name: terraform fmt
+        run: terraform fmt -check
+        continue-on-error: true
+      - name: terraform init
+        run: terraform init -backend=false -input=false
+      - name: terraform validate
+        run: terraform validate -no-color
+  


### PR DESCRIPTION
- Rename to "Tests" because it includes all components
- Upgrade Go to the latest stable version (1.24 now)
- Upgrade Node to use the current LTS 22
- Add Terraform syntax validation
- Restrict permissions to read only
- Upgrade actions/checkout@v3 to v4
- Upgrade actions/setup-go@v3 to v4
- Upgrade actions/setup-node@v3 to v4

https://github.com/GoogleCloudPlatform/gcping/issues/172